### PR TITLE
Formatting の追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 [[package]]
 name = "satysfi-formatter"
 version = "0.1.0"
-source = "git+https://github.com/usagrada/satysfi-formatter.git?branch=feature/lsp#da97b5787e0804d88ad47794d88aab74b10753ff"
+source = "git+https://github.com/usagrada/satysfi-formatter.git?branch=feature/lsp#5038db390d4a9957ad03c85845c1957f077986c0"
 dependencies = [
  "clap 3.2.2",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 [[package]]
 name = "satysfi-formatter"
 version = "0.1.0"
-source = "git+https://github.com/usagrada/satysfi-formatter.git?branch=feature/lsp#5038db390d4a9957ad03c85845c1957f077986c0"
+source = "git+https://github.com/usagrada/satysfi-formatter.git?branch=main#cbf2e50d246b905e21037d6df119e4503f04c250"
 dependencies = [
  "clap 3.2.2",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,10 +106,49 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
- "textwrap",
+ "strsim 0.8.0",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e538f9ee5aa3b3963f09a997035f883677966ed50fce0292611927ce6f6d8c6"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.2",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f98063cac4652f23ccda556b8d04347a7fc4b2cff1f7577cc8c6546e0d8078"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -120,6 +159,26 @@ checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if",
  "num_cpus",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -229,10 +288,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -242,6 +318,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -276,6 +358,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,9 +399,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.109"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98a04dce437184842841303488f70d0188c5f51437d2a834dc097eafa909a01"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lock_api"
@@ -373,7 +465,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca1d48da0e4a6100b4afd52fae99f36d47964a209624021280ad9ffdd410e83d"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -456,6 +548,12 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -571,11 +669,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -602,6 +711,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
 
 [[package]]
+name = "satysfi-formatter"
+version = "0.1.0"
+source = "git+https://github.com/usagrada/satysfi-formatter.git?branch=feature/lsp#da97b5787e0804d88ad47794d88aab74b10753ff"
+dependencies = [
+ "clap 3.2.2",
+ "dirs",
+ "lspower",
+ "satysfi-parser 0.0.3 (git+https://github.com/usagrada/satysfi-parser.git)",
+]
+
+[[package]]
 name = "satysfi-language-server"
 version = "0.0.1"
 dependencies = [
@@ -613,7 +733,8 @@ dependencies = [
  "lspower",
  "peg",
  "regex",
- "satysfi-parser",
+ "satysfi-formatter",
+ "satysfi-parser 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "simplelog",
  "structopt",
@@ -627,6 +748,20 @@ name = "satysfi-parser"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39274032a5660839ff938cee9e28358c92a1206e315194490304d7d613109d7"
+dependencies = [
+ "anyhow",
+ "glob",
+ "itertools",
+ "log",
+ "peg",
+ "structopt",
+ "thiserror",
+]
+
+[[package]]
+name = "satysfi-parser"
+version = "0.0.3"
+source = "git+https://github.com/usagrada/satysfi-parser.git#d89da3dd653abbdc6ee6c220fbfeef862c963863"
 dependencies = [
  "anyhow",
  "glob",
@@ -724,12 +859,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -740,7 +881,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -777,6 +918,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,7 +950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -961,6 +1108,12 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ satysfi-parser = "0.0.3"
 peg = "0.7.0"
 glob = "0.3.0"
 regex = "1.5.4"
-satysfi-formatter = { git = "https://github.com/usagrada/satysfi-formatter.git", branch = "feature/lsp" }
+satysfi-formatter = { git = "https://github.com/usagrada/satysfi-formatter.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ satysfi-parser = "0.0.3"
 peg = "0.7.0"
 glob = "0.3.0"
 regex = "1.5.4"
+satysfi-formatter = { git = "https://github.com/usagrada/satysfi-formatter.git", branch = "feature/lsp" }

--- a/src/language_server.rs
+++ b/src/language_server.rs
@@ -145,11 +145,11 @@ impl Inner {
         let d_data = self.documents.0.get(&uri).unwrap();
         match d_data {
             DocumentData::Parsed { program_text, .. } => {
-                let result = satysfi_formatter::format_lsp(&program_text.text, params.options);
+                let result = satysfi_formatter::formatting(&program_text.text, params.options);
                 Some(result)
             }
             DocumentData::NotParsed { text, .. } => {
-                let result = satysfi_formatter::format_lsp(&text, params.options);
+                let result = satysfi_formatter::formatting(&text, params.options);
                 Some(result)
             }
         }

--- a/src/language_server.rs
+++ b/src/language_server.rs
@@ -3,8 +3,9 @@ use lspower::{
     jsonrpc::Result as LspResult,
     lsp::{
         CompletionParams, CompletionResponse, DidChangeTextDocumentParams,
-        DidOpenTextDocumentParams, DidSaveTextDocumentParams, GotoDefinitionParams,
-        GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializeResult, ServerInfo,
+        DidOpenTextDocumentParams, DidSaveTextDocumentParams, DocumentFormattingParams,
+        GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
+        InitializeResult, ServerInfo, TextEdit,
     },
 };
 use std::sync::Arc;
@@ -65,6 +66,13 @@ impl lspower::LanguageServer for LanguageServer {
         params: GotoDefinitionParams,
     ) -> LspResult<Option<GotoDefinitionResponse>> {
         self.0.lock().await.goto_definition(params).await
+    }
+
+    async fn formatting(
+        &self,
+        params: DocumentFormattingParams,
+    ) -> LspResult<Option<Vec<TextEdit>>> {
+        Ok(self.0.lock().await.formatting(params).await)
     }
 
     async fn shutdown(&self) -> LspResult<()> {
@@ -129,6 +137,21 @@ impl Inner {
                 .get_completion_list(&curpos, trigger.as_deref()))
         } else {
             Ok(None)
+        }
+    }
+
+    async fn formatting(&self, params: DocumentFormattingParams) -> Option<Vec<TextEdit>> {
+        let uri = params.text_document.uri;
+        let d_data = self.documents.0.get(&uri).unwrap();
+        match d_data {
+            DocumentData::Parsed { program_text, .. } => {
+                let result = satysfi_formatter::format_lsp(&program_text.text, params.options);
+                Some(result)
+            }
+            DocumentData::NotParsed { text, .. } => {
+                let result = satysfi_formatter::format_lsp(&text, params.options);
+                Some(result)
+            }
         }
     }
 

--- a/src/language_server/capabilities.rs
+++ b/src/language_server/capabilities.rs
@@ -1,6 +1,6 @@
 use lspower::lsp::{
     ClientCapabilities, CompletionOptions, HoverProviderCapability, OneOf, ServerCapabilities,
-    TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextDocumentSyncCapability, TextDocumentSyncKind, DocumentFormattingOptions, WorkDoneProgressOptions,
 };
 
 /// Client の capabilities に合わせて Server 側の capabilities を返す。
@@ -32,7 +32,7 @@ pub fn server_capabilities(_client_capabilities: &ClientCapabilities) -> ServerC
         workspace_symbol_provider: None,
         code_action_provider: None,
         code_lens_provider: None,
-        document_formatting_provider: None,
+        document_formatting_provider: Some(OneOf::Left(true)),
         document_range_formatting_provider: None,
         document_on_type_formatting_provider: None,
         rename_provider: None,


### PR DESCRIPTION
formattingを可能にしました。
フォーマッタの方でもLSP の互換性を持つよう変更を行いました。手元の環境で、フォーマットのリクエストが動作することを確認（VS Code）しております。

v0.1.x に切り替わるタイミングで、修正が必要になるとは思いますが、v0.0.x に関しては、現在の設計でいかがでしょうか？
修正等があれば、こちらで直す形でも直していただく形でも大丈夫です（そのままCloseしていただいても構いません）。

今後、別のフォーマッタに切り替えたい場合には `async fn formatting(&self, params: DocumentFormattingParams) -> Option<Vec<TextEdit>>` の内部を書き換えることで、切り替えることができます。